### PR TITLE
Initial implementation of forwardPorts()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.DS_Store
+*.sw?

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- 0.10

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,135 @@
-# node-firefox-forward-ports
-Forward local ports to remote debugging interfaces on connected Firefox OS devices
+# node-firefox-forward-ports [![Build Status](https://secure.travis-ci.org/mozilla/node-firefox-forward-ports.png?branch=master)](http://travis-ci.org/mozilla/node-firefox-forward-ports)
+
+> Forward local ports to remote debugging interfaces on connected Firefox OS devices
+
+[![Install with NPM](https://nodei.co/npm/node-firefox-forward-ports.png?downloads=true&stars=true)](https://nodei.co/npm/node-firefox-forward-ports/)
+
+This is part of the [node-firefox](https://github.com/mozilla/node-firefox) project.
+
+Firefox OS devices offer a [Remote Debugging service](https://wiki.mozilla.org/Remote_Debugging_Protocol) 
+on a local network socket. This can be forwarded to a host computer over USB
+using ADB. This module takes care of that as necessary, reusing forwarded ports
+when possible.
+
+## Installation
+
+### From git
+
+```bash
+git clone https://github.com/mozilla/node-firefox-forward-ports.git
+cd node-firefox-forward-ports
+npm install
+```
+
+If you want to update later on:
+
+```bash
+cd node-firefox-forward-ports
+git pull origin master
+npm install
+```
+
+### npm
+
+```bash
+npm install node-firefox-forward-ports
+```
+
+## Usage
+
+```javascript
+var forwardPorts = require('node-firefox-forward-ports');
+
+// Forwards ports as necessary, while reusing existing ports.
+// Returns the list of devices annotated with details on forwarded ports.
+forwardPorts({
+  devices: [
+    {id: '3739ced5'},
+    {id: 'full_keon'},
+    {id: 'full_unagi'}
+  ]
+}).then(function(results) {
+  console.log(results);
+}).catch(function(err) {
+  console.error(err);
+});
+```
+
+## Example
+
+This example uses [node-firefox-find-devices](https://github.com/mozilla/node-firefox-find-devices)
+to first assemble a list of connected Firefox OS devices. The output of
+`findDevices()` is basically what `forwardPorts()` expects for its `devices`
+option.
+
+```javascript
+var findDevices = require('node-firefox-find-devices');
+var forwardPorts = require('node-firefox-forward-ports');
+
+findDevices().then(function (devices) {
+  return forwardPorts({
+    devices: devices
+  });
+}).then(function(results) {
+  console.log(results);
+});
+```
+
+This example would result in output like the following, which consists of the
+output of `findDevices()` altered to include a list of forward ports for each
+device.
+
+```javascript
+[
+  {
+    "id": "3739ced5",
+    "type": "device",
+    "isFirefoxOS": true,
+    "ports": [
+      {
+        "local": "tcp:8001",
+        "remote": "localfilesystem:/data/local/debugger-socket",
+        "port": "8001"
+      }
+    ]
+  }
+]
+```
+
+The listing of each device returned from `findDevices()` will be annotated with
+a new `ports` property. This is a list of details on each port forwarded to the
+device.
+
+The `local` property contains the local side of the port forward. If this is a
+TCP/IP port, then its numerical port can be found in the `port` property.
+
+The `remote` property contains the remote side of the port forward, useful for
+filtering and selecting particular kinds of forwarded ports. Currently, this
+module only supports Firefox remote debugging sockets - but that could expand
+in the future.
+
+## Running the tests
+
+After installing, you can simply run the following from the module folder:
+
+```bash
+npm test
+```
+
+To add a new unit test file, create a new file in the `tests/unit` folder. Any file that matches `test.*.js` will be run as a test by the appropriate test runner, based on the folder location.
+
+We use `gulp` behind the scenes to run the test; if you don't have it installed globally you can use `npm gulp` from inside the project's root folder to run `gulp`.
+
+### Code quality and style
+
+Because we have multiple contributors working on our projects, we value consistent code styles. It makes it easier to read code written by many people! :-)
+
+Our tests include unit tests as well as code quality ("linting") tests that make sure our test pass a style guide and [JSHint](http://jshint.com/). Instead of submitting code with the wrong indentation or a different style, run the tests and you will be told where your code quality/style differs from ours and instructions on how to fix it.
+
+This program is free software; it is distributed under an
+[Apache License](https://github.com/mozilla/node-firefox-forward-ports/blob/master/LICENSE).
+
+## Copyright
+
+Copyright (c) 2015 [Mozilla](https://mozilla.org)
+([Contributors](https://github.com/mozilla/node-firefox-forward-ports/graphs/contributors)).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ var forwardPorts = require('node-firefox-forward-ports');
 
 // Forwards ports as necessary, while reusing existing ports.
 // Returns the list of devices annotated with details on forwarded ports.
+forwardPorts([
+  {id: '3739ced5'},
+  {id: 'full_keon'},
+  {id: 'full_unagi'}
+]).then(function(results) {
+  console.log(results);
+}).catch(function(err) {
+  console.error(err);
+});
+
+// forwardPorts() can also accept an options object, for future expansion
+// when additional options are supported.
 forwardPorts({
   devices: [
     {id: '3739ced5'},
@@ -53,6 +65,7 @@ forwardPorts({
 }).catch(function(err) {
   console.error(err);
 });
+
 ```
 
 ## Example
@@ -66,11 +79,7 @@ option.
 var findDevices = require('node-firefox-find-devices');
 var forwardPorts = require('node-firefox-forward-ports');
 
-findDevices().then(function (devices) {
-  return forwardPorts({
-    devices: devices
-  });
-}).then(function(results) {
+findDevices().then(forwardPorts).then(function(results) {
   console.log(results);
 });
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,3 @@
+var gulp = require('gulp');
+
+require('node-firefox-build-tools').loadGulpTasks(gulp);

--- a/index.js
+++ b/index.js
@@ -11,8 +11,15 @@ var REMOTE_DEBUGGER_SOCKET = 'localfilesystem:/data/local/debugger-socket';
 module.exports = forwardPorts;
 
 function forwardPorts(options) {
-  options = options || {};
-  var devices = options.devices;
+
+  var devices;
+
+  if (Array.isArray(options)) {
+    devices = options;
+  } else {
+    options = options || {};
+    devices = options.devices;
+  }
 
   var adbClient = adb.createClient();
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,108 @@
+'use strict';
+
+// See https://github.com/jshint/jshint/issues/1747 for context
+/* global -Promise */
+var Promise = require('es6-promise').Promise;
+var adb = require('adbkit');
+var portfinder = require('portfinder');
+
+var REMOTE_DEBUGGER_SOCKET = 'localfilesystem:/data/local/debugger-socket';
+
+module.exports = forwardPorts;
+
+function forwardPorts(options) {
+  options = options || {};
+  var devices = options.devices;
+
+  var adbClient = adb.createClient();
+
+  return new Promise(function(resolve, reject) {
+    if (devices === undefined || !Array.isArray(devices)) {
+      return reject(new Error('an array of devices is required to forward ports'));
+    }
+    return resolve();
+  }).then(function() {
+    return findExistingPortForwards(adbClient, devices);
+  }).then(function(devicesWithPorts) {
+    return forwardDevices(adbClient, devicesWithPorts);
+  });
+}
+
+function findExistingPortForwards(adbClient, devices) {
+  return adbClient.listForwards().then(function(ports) {
+
+    // Index the list of forwarded ports by device ID.
+    var portMap = {};
+    ports.forEach(function(port) {
+
+      // Filter for remote debugging sockets, just in case something else has
+      // been forwarded.
+      if (port.remote !== REMOTE_DEBUGGER_SOCKET) {
+        return;
+      }
+
+      // Add this port to a list associated with the device ID
+      if (!portMap[port.serial]) {
+        portMap[port.serial] = [];
+      }
+      portMap[port.serial].push(port);
+
+    });
+
+    // Annotate the list of devices with associated ports.
+    return devices.map(function(device) {
+      device.ports = portMap[device.id] || [];
+      return device;
+    });
+
+  });
+}
+
+function forwardDevices(adbClient, devices) {
+  return Promise.all(devices.map(function(device) {
+
+    if (device.ports.length > 0) {
+      // Skip forwarding for this device. But, extract port number from the
+      // tcp:{port} format returned by adbClient.listForwards()
+      device.ports.forEach(function(port) {
+        delete port.serial;
+        if (port.local.indexOf('tcp:') === -1) {
+          port.port = null;
+        } else {
+          port.port = port.local.replace('tcp:', '');
+        }
+      });
+      return device;
+    }
+
+    return getPort().then(function(port) {
+      var localAddress = 'tcp:' + port;
+      var remoteAddress = REMOTE_DEBUGGER_SOCKET;
+      return adbClient
+        .forward(device.id, localAddress, remoteAddress)
+        .then(function() {
+          device.ports = [
+            {
+              port: port,
+              local: localAddress,
+              remote: remoteAddress
+            }
+          ];
+          return device;
+        });
+    });
+
+  }));
+}
+
+function getPort() {
+  return new Promise(function(resolve, reject) {
+    portfinder.getPort({
+      // Ensure we're looking at localhost, rather than 0.0.0.0
+      // see: https://github.com/indexzero/node-portfinder/issues/13
+      host: '127.0.0.1'
+    }, function(err, port) {
+      return err ? reject(err) : resolve(port);
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "node-firefox-forward-ports",
+  "version": "1.0.0",
+  "description": "Forward local ports to remote debugging interfaces on connected Firefox OS devices",
+  "main": "index.js",
+  "dependencies": {
+    "adbkit": "^2.1.6",
+    "es6-promise": "^2.0.1",
+    "portfinder": "^0.4.0"
+  },
+  "devDependencies": {
+    "gulp": "^3.8.10",
+    "mockery": "^1.4.0",
+    "node-firefox-build-tools": "^0.1.0",
+    "nodemock": "^0.3.4"
+  },
+  "scripts": {
+    "gulp": "gulp",
+    "test": "gulp test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/node-firefox-forward-ports.git"
+  },
+  "keywords": [
+    "firefox",
+    "developer tools",
+    "b2g",
+    "firefox os",
+    "firefoxos",
+    "fxos",
+    "ports"
+  ],
+  "author": "Mozilla (https://mozilla.org/)",
+  "contributors": [
+    "Les Orchard <me@lmorchard.com> (http://lmorchard.com)"
+  ],
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/mozilla/node-firefox-forward-ports/issues"
+  },
+  "homepage": "https://github.com/mozilla/node-firefox-forward-ports"
+}

--- a/tests/unit/test.index.js
+++ b/tests/unit/test.index.js
@@ -32,15 +32,21 @@ module.exports = {
     });
   },
 
-  // Note: These two tests are mostly identical, except for whether forwarded
+  // Note: These tests are mostly identical, except for whether forwarded
   // ports already exist. In either case, whether ports are quietly reused or
   // new ones forwarded, the end result returned to the developer is the same.
 
-  'forwardPorts() should forward a port for a device not yet forwarded':
-    commonForwardTest(false),
+  'forwardPorts({ devices: devices }) should forward a port for a device not yet forwarded':
+    commonForwardTest(false, true),
 
-  'forwardPorts() should skip forwarding for devices that have forwarded ports':
-    commonForwardTest(true),
+  'forwardPorts({ devices: devices }) should skip forwarding for devices that have forwarded ports':
+    commonForwardTest(true, true),
+
+  'forwardPorts(devices) should forward a port for a device not yet forwarded':
+    commonForwardTest(false, false),
+
+  'forwardPorts(devices) should skip forwarding for devices that have forwarded ports':
+    commonForwardTest(true, false),
 
   tearDown: function(done) {
     mockery.disable();
@@ -49,7 +55,7 @@ module.exports = {
 
 };
 
-function commonForwardTest(detectForwardedPorts) {
+function commonForwardTest(detectForwardedPorts, useOptions) {
   return function(test) {
 
     var port = 9999;
@@ -134,9 +140,14 @@ function commonForwardTest(detectForwardedPorts) {
     });
 
     // Require a freshly imported forwardPorts for this test
-    require('../../index')({
-      devices: devices
-    }).catch(function(err) {
+    var forwardPortsWithMocks = require('../../index');
+
+    // forwardPorts() can accept a simple device list, or a full options object.
+    var forwardPortsPromise = (useOptions) ?
+      forwardPortsWithMocks({ devices: devices }) :
+      forwardPortsWithMocks(devices);
+
+    forwardPortsPromise.catch(function(err) {
       test.ifError(err);
       test.done();
     }).then(function(results) {

--- a/tests/unit/test.index.js
+++ b/tests/unit/test.index.js
@@ -1,0 +1,168 @@
+'use strict';
+
+/* global -Promise */
+var Promise = require('es6-promise').Promise;
+var mockery = require('mockery');
+var nodemock = require('nodemock');
+
+var forwardPorts = require('../../index');
+
+// nodemock expects an empty function to indicate a callback parameter
+var CALLBACK_TYPE = function() {};
+
+module.exports = {
+
+  'forwardPorts() should yield an error if the devices option is missing': function(test) {
+    forwardPorts().then(function(results) {
+      test.ok(false);
+      test.done();
+    }).catch(function(err) {
+      test.done();
+    });
+  },
+
+  'forwardPorts() should yield an error if the devices option is not an array': function(test) {
+    forwardPorts({
+      devices: 'LOL NOT AN ARRAY'
+    }).then(function(results) {
+      test.ok(false);
+      test.done();
+    }).catch(function(err) {
+      test.done();
+    });
+  },
+
+  // Note: These two tests are mostly identical, except for whether forwarded
+  // ports already exist. In either case, whether ports are quietly reused or
+  // new ones forwarded, the end result returned to the developer is the same.
+
+  'forwardPorts() should forward a port for a device not yet forwarded':
+    commonForwardTest(false),
+
+  'forwardPorts() should skip forwarding for devices that have forwarded ports':
+    commonForwardTest(true),
+
+  tearDown: function(done) {
+    mockery.disable();
+    done();
+  }
+
+};
+
+function commonForwardTest(detectForwardedPorts) {
+  return function(test) {
+
+    var port = 9999;
+    var deviceId = '8675309';
+    var localAddress = 'tcp:'+port;
+    var remoteAddress = 'localfilesystem:/data/local/debugger-socket';
+    var devices = [ { id: deviceId } ];
+
+    var mocked;
+
+    // Vary the test on whether existing forwarded ports should be detected
+    if (detectForwardedPorts) {
+
+      // Report existing port forwards for the device.
+      mocked = nodemock
+        .mock('listForwards')
+        .returns(new Promise(function(resolve, reject) {
+          resolve([
+
+            // This is a Firefox remote debugging socket, using test values.
+            {
+              serial: deviceId,
+              local: localAddress,
+              remote: remoteAddress
+            },
+
+            // Note: This is a socket we're not interested in, so it shouldn't
+            // end up in results.
+            {
+              serial: deviceId,
+              local: 'tcp:2112',
+              remote: 'localfilesystem:/data/local/some-other-socket'
+            }
+
+          ]);
+        }));
+
+      // Any call to portfinder.getPort() or client.forward() is a failure,
+      // because port forwarding should be skipped.
+      mocked.mock('getPort').fail();
+      mocked.mock('forward').fail();
+
+    } else {
+
+      // Report no existing port forwards for the device.
+      mocked = nodemock
+        .mock('listForwards')
+        .returns(new Promise(function(resolve, reject) {
+          resolve([]);
+        }));
+
+      // portfinder.getPort() should be called to discover a free port.
+      mocked.mock('getPort')
+        .takes({ host: '127.0.0.1' }, CALLBACK_TYPE)
+        .calls(1, [null, port]);
+
+      // client.forward() should be called to create the port forward.
+      mocked.mock('forward')
+        .takes(deviceId, localAddress, remoteAddress)
+        .returns(new Promise(function(resolve, reject) { resolve(); }));
+
+    }
+
+    mockery.registerMock('portfinder', {
+      getPort: mocked.getPort
+    });
+
+    mocked.mock('createClient').returns({
+      listForwards: mocked.listForwards,
+      forward: mocked.forward
+    });
+
+    mockery.registerMock('adbkit', {
+      createClient: mocked.createClient
+    });
+
+    // Enable mocks on a clear import cache
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    });
+
+    // Require a freshly imported forwardPorts for this test
+    require('../../index')({
+      devices: devices
+    }).catch(function(err) {
+      test.ifError(err);
+      test.done();
+    }).then(function(results) {
+
+      // Ensure all the mocks were called, and with the expected parameters
+      test.ok(mocked.assert());
+
+      // Result should be an array of one device.
+      test.ok(Array.isArray(results));
+      test.equal(results.length, 1);
+
+      // The single device should list device and port details.
+      var result = results[0];
+      test.equal(result.id, deviceId);
+
+      // There should only be one port - the other one should have been ignored.
+      test.equal(result.ports.length, 1);
+      test.deepEqual(result.ports[0], {
+        port: port,
+        local: localAddress,
+        remote: remoteAddress
+      });
+
+      test.done();
+
+    });
+
+  };
+}


### PR DESCRIPTION
So, here's a thing that forwards ports. @sole, @tofumatt, and/or @fwenzel - care to take a peek?

Seems to work with the half-dozen devices I hooked up to my computer - 3 android, 3 fxos.

One thing I was considering simplifying, though, is the list of ports resulting from forwardPorts(). Right now I just dumped in everything that the ADB client returned. But, it might be more handy to reduce that to just a simple list of ports - or maybe just a single port, assuming we only get one port forward to the debugging interface.
